### PR TITLE
fix: add xkcd module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyTelegramBotAPI==3.6.7
 requests==2.23.0
 six==1.14.0
 urllib3==1.25.8
+xkcd==2.4.2


### PR DESCRIPTION
```xkcd``` module is being imported but is not supplied in requirements.txt.